### PR TITLE
build: update deps via npm audit fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1989,14 +1989,14 @@
       }
     },
     "node_modules/@openzeppelin/contracts": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.7.0.tgz",
-      "integrity": "sha512-52Qb+A1DdOss8QvJrijYYPSf32GUg2pGaG/yCxtaA3cu4jduouTdg4XZSMLW9op54m1jH7J8hoajhHKOPsoJFw=="
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.7.3.tgz",
+      "integrity": "sha512-dGRS0agJzu8ybo44pCIf3xBaPQN/65AIXNgK8+4gzKd5kbvlqyxryUYVLJv7fK98Seyd2hDZzVEHSWAh0Bt1Yw=="
     },
     "node_modules/@openzeppelin/contracts-upgradeable": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.7.0.tgz",
-      "integrity": "sha512-wO3PyoAaAV/rA77cK8H4c3SbO98QylTjfiFxyvURUZKTFLV180rnAvna1x7/Nxvt0Gqv+jt1sXKC7ygxsq8iCw=="
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.7.3.tgz",
+      "integrity": "sha512-+wuegAMaLcZnLCJIvrVUDzA9z/Wp93f0Dla/4jJvIhijRrPabjQbZe6fWiECLaJyfn5ci9fqf9vTw3xpQOad2A=="
     },
     "node_modules/@pedrouid/environment": {
       "version": "1.0.1",
@@ -11373,14 +11373,14 @@
       }
     },
     "@openzeppelin/contracts": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.7.0.tgz",
-      "integrity": "sha512-52Qb+A1DdOss8QvJrijYYPSf32GUg2pGaG/yCxtaA3cu4jduouTdg4XZSMLW9op54m1jH7J8hoajhHKOPsoJFw=="
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.7.3.tgz",
+      "integrity": "sha512-dGRS0agJzu8ybo44pCIf3xBaPQN/65AIXNgK8+4gzKd5kbvlqyxryUYVLJv7fK98Seyd2hDZzVEHSWAh0Bt1Yw=="
     },
     "@openzeppelin/contracts-upgradeable": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.7.0.tgz",
-      "integrity": "sha512-wO3PyoAaAV/rA77cK8H4c3SbO98QylTjfiFxyvURUZKTFLV180rnAvna1x7/Nxvt0Gqv+jt1sXKC7ygxsq8iCw=="
+      "version": "4.7.3",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-upgradeable/-/contracts-upgradeable-4.7.3.tgz",
+      "integrity": "sha512-+wuegAMaLcZnLCJIvrVUDzA9z/Wp93f0Dla/4jJvIhijRrPabjQbZe6fWiECLaJyfn5ci9fqf9vTw3xpQOad2A=="
     },
     "@pedrouid/environment": {
       "version": "1.0.1",


### PR DESCRIPTION
## Summary

Closes #14 

This PR updates the `@openzeppelin/contracts` and `@openzeppelin/contracts-upgradeable` dependencies to the latest versions, fixing the previously reported security vulnerabilities reference in the backing issue.

cc: @0xTranqui for review 👀