### PR TITLE
FIX: image scaling for non square images.

### DIFF
--- a/components/EditionCard.tsx
+++ b/components/EditionCard.tsx
@@ -219,13 +219,14 @@ const EditionCard = ({ editionAddress }) => {
                         </div>   
                         ) : (
                         <div  className="   border-[1px] border-[#00C2FF] text-[#00C2FF] h-[100%] w-full text-[#00C2FF] flex flex-row flex-wrap justify-center ">
-                            <div className=" flex flex-row sm:w-[100%] justify-center border-b-[1px] border-[#00C2FF]">
-                                <Image 
-                                    src={editionsImageSRC}
-                                    // layout={"fill"
-                                    width={354}
-                                    height={354}                                                        
-                                />                            
+                            <div className=" flex flex-row sm:w-[100%] justify-center border-b-[1px] border-[#00C2FF] relative" style={{width: 354, height: 354 }}>
+                                <div className="">
+                                    <Image 
+                                        src={editionsImageSRC}
+                                        layout="fill"
+                                        objectFit='cover'        
+                                    />
+                                </div>        
                             </div>
                             { mintWaitLoading == false && mintOverlayState == true && mintStatus == "success" ? (
                             <div className=" h-[268px] bg-[#00C2FF] flex flex-row sm:w-[100%] justify-center items-center  ">

--- a/components/EditionCard.tsx
+++ b/components/EditionCard.tsx
@@ -219,8 +219,8 @@ const EditionCard = ({ editionAddress }) => {
                         </div>   
                         ) : (
                         <div  className="   border-[1px] border-[#00C2FF] text-[#00C2FF] h-[100%] w-full text-[#00C2FF] flex flex-row flex-wrap justify-center ">
-                            <div className=" flex flex-row sm:w-[100%] justify-center border-b-[1px] border-[#00C2FF] relative" style={{width: 354, height: 354 }}>
-                                <div className="">
+                            <div className=" flex flex-row sm:w-[100%] justify-center border-b-[1px] border-[#00C2FF]">
+                                <div className="relative" style={{width: 354, height: 354 }}>
                                     <Image 
                                         src={editionsImageSRC}
                                         layout="fill"


### PR DESCRIPTION
change edition card image wrapper to absolute size, object-fit cover on next image

<img width="1456" alt="Screen Shot 2022-09-02 at 4 54 57 PM" src="https://user-images.githubusercontent.com/7268786/188247469-6842bbef-091f-4da5-9e52-0515ad8c988f.png">

@0xTranqui - other option is to make it keep it's natural aspect ratio: (although this throws the scaling of the other images within the container off just a little... so overall does not look as good without some extra special handling.

figure most images will be square.

<img width="1236" alt="Screen Shot 2022-09-02 at 4 56 59 PM" src="https://user-images.githubusercontent.com/7268786/188247532-b00a2a92-475a-42d5-a5a1-f21586978d39.png">
