### PR TITLE
feat: randomize rendered collections on every page load

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "erc-token-abis": "^1.0.0",
         "ethers": "^5.6.9",
         "graphql": "^16.5.0",
+        "lodash.shuffle": "^4.2.0",
         "next": "12.2.1",
         "nft.storage": "^7.0.0",
         "react": "^17.0.2",
@@ -6958,6 +6959,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/lodash.shuffle": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.shuffle/-/lodash.shuffle-4.2.0.tgz",
+      "integrity": "sha512-V/rTAABKLFjoecTZjKSv+A1ZomG8hZg8hlgeG6wwQVD9AGv+10zqqSf6mFq2tVA703Zd5R0YhSuSlXA+E/Ei+Q=="
     },
     "node_modules/loglevel": {
       "version": "1.8.0",
@@ -15268,6 +15274,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "lodash.shuffle": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.shuffle/-/lodash.shuffle-4.2.0.tgz",
+      "integrity": "sha512-V/rTAABKLFjoecTZjKSv+A1ZomG8hZg8hlgeG6wwQVD9AGv+10zqqSf6mFq2tVA703Zd5R0YhSuSlXA+E/Ei+Q=="
     },
     "loglevel": {
       "version": "1.8.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "erc-token-abis": "^1.0.0",
     "ethers": "^5.6.9",
     "graphql": "^16.5.0",
+    "lodash.shuffle": "^4.2.0",
     "next": "12.2.1",
     "nft.storage": "^7.0.0",
     "react": "^17.0.2",

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -6,6 +6,7 @@ import { Footer } from '../components/Footer'
 import * as CurationManager from "../contractABI/CurationManager.json"
 import EditionCard from '../components/EditionCard';
 import Image from 'next/image'
+import shuffle from 'lodash/shuffle'
 
 const Home: NextPage = () => {
 
@@ -24,8 +25,8 @@ const Home: NextPage = () => {
   })
   
   const collectionData = data ? data : []
-  const collectionDataReverseOrder = [...collectionData].reverse();
-  
+  const shuffledCollectionData = shuffle(collectionData)
+
   const rowAndColumnCount = collectionData.length
 
   return (
@@ -64,8 +65,8 @@ const Home: NextPage = () => {
       </div>
       <main className={` pb-8 sm:pb-[70px] text-white grid grid-rows-[${rowAndColumnCount}]  flex justify-center lg:grid-cols-3 sm:grid-cols-2  w-[90%] sm:w-[80%]  gap-y-8 sm:gap-y-[70px]  gap-x-0 sm:gap-x-[70px]`}> 
       {
-        collectionDataReverseOrder.map((collection, index) =>
-          <EditionCard editionAddress={collectionDataReverseOrder[index]} key={collection} />
+        shuffledCollectionData.map((collection, index) =>
+          <EditionCard editionAddress={shuffledCollectionData[index]} key={collection} />
         )
       }
       </main>


### PR DESCRIPTION
## Summary

Closes #19 

Previously, the home page rendered each of the edition collections by the date they were created. This PR randomizes the rendered collection on every page load, powered by [`lodash.shuffle`](https://www.npmjs.com/package/lodash.shuffle) (the one new dependency). 

I tested these changes in local development. I'd be happy to test these to a staging deploy before having this merged in.

cc: @0xTranqui for review 👓 